### PR TITLE
Added null checks for the uses of getWorld() in PartPipe and PartWireSignalBase

### DIFF
--- a/src/main/java/pl/asie/charset/pipes/pipe/PartPipe.java
+++ b/src/main/java/pl/asie/charset/pipes/pipe/PartPipe.java
@@ -569,7 +569,7 @@ public class PartPipe extends Multipart implements IConnectable, ISlottedPart, I
 
 	@Override
 	public int injectItem(ItemStack stack, EnumFacing direction, boolean simulate) {
-		if (getWorld() != null && getWorld().isRemote || !connects(direction)) {
+		if (getWorld() == null && getWorld().isRemote || !connects(direction)) {
 			return 0;
 		}
 

--- a/src/main/java/pl/asie/charset/pipes/pipe/PartPipe.java
+++ b/src/main/java/pl/asie/charset/pipes/pipe/PartPipe.java
@@ -354,7 +354,7 @@ public class PartPipe extends Multipart implements IConnectable, ISlottedPart, I
 	@Override
 	public void onUnloaded() {
 		super.onUnloaded();
-		if (getWorld().isRemote) {
+		if (getWorld() != null && getWorld().isRemote) {
 			synchronized (itemSet) {
 				itemSet.clear();
 			}
@@ -442,7 +442,7 @@ public class PartPipe extends Multipart implements IConnectable, ISlottedPart, I
 	}
 
 	private void updateNeighborInfo(boolean sendPacket) {
-		if (!getWorld().isRemote) {
+		if (getWorld() != null && !getWorld().isRemote) {
 			byte oc = connectionCache;
 
 			for (EnumFacing dir : EnumFacing.VALUES) {
@@ -499,7 +499,7 @@ public class PartPipe extends Multipart implements IConnectable, ISlottedPart, I
 	}
 
 	protected void addItemClientSide(PipeItem item) {
-		if (!getWorld().isRemote) {
+		if (getWorld() == null && !getWorld().isRemote) {
 			return;
 		}
 
@@ -521,7 +521,7 @@ public class PartPipe extends Multipart implements IConnectable, ISlottedPart, I
 	}
 
 	protected void removeItemClientSide(PipeItem item) {
-		if (getWorld().isRemote) {
+		if (getWorld() != null && getWorld().isRemote) {
 			synchronized (itemSet) {
 				itemSet.remove(item);
 			}
@@ -569,7 +569,7 @@ public class PartPipe extends Multipart implements IConnectable, ISlottedPart, I
 
 	@Override
 	public int injectItem(ItemStack stack, EnumFacing direction, boolean simulate) {
-		if (getWorld().isRemote || !connects(direction)) {
+		if (getWorld() != null && getWorld().isRemote || !connects(direction)) {
 			return 0;
 		}
 

--- a/src/main/java/pl/asie/charset/wires/logic/PartWireSignalBase.java
+++ b/src/main/java/pl/asie/charset/wires/logic/PartWireSignalBase.java
@@ -72,7 +72,7 @@ public abstract class PartWireSignalBase extends PartWire implements
 
 	@Override
 	protected void logicUpdate() {
-		if (!getWorld().isRemote) {
+		if (getWorld() != null && !getWorld().isRemote) {
 			onSignalChanged(-1);
 		}
 	}


### PR DESCRIPTION
The Multipart.getWorld() method has the possibility of returning null.

This will fix https://github.com/Vazkii/Charset/issues/11, even though I couldn't reproduce the issue.
