### PR TITLE
Update to 1.10.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,12 @@ repositories {
 }
 
 dependencies {
-	deobfCompile "MCMultiPart:MCMultiPart-experimental:1.2.0_73:universal"
-	deobfCompile "mezz.jei:jei_1.10:3.7.0.218"
+	deobfCompile "MCMultiPart:MCMultiPart-experimental:1.3.0_83:universal"
+	deobfCompile "mezz.jei:jei_1.10.2:3.12.7.312"
 }
 
 minecraft {
-	version = "1.10-12.18.0.1986-1.10.0"
+	version = "1.10.2-12.18.2.2099"
 
 	runDir = "run"
 	useDepAts = true

--- a/src/main/java/pl/asie/charset/audio/recipe/JEIPluginCharsetAudio.java
+++ b/src/main/java/pl/asie/charset/audio/recipe/JEIPluginCharsetAudio.java
@@ -20,15 +20,30 @@ import mezz.jei.api.*;
 
 import javax.annotation.Nonnull;
 
+import mezz.jei.api.ingredients.IModIngredientRegistration;
+
 @JEIPlugin
 public class JEIPluginCharsetAudio implements IModPlugin {
+	public static IJeiHelpers jeiHelpers;
+	
 	@Override
 	public void register(IModRegistry registry) {
+		jeiHelpers = registry.getJeiHelpers();
 		registry.addRecipeHandlers(new JEITapeCraftingRecipe.Handler(), new JEITapeReelCraftingRecipe.Handler());
 	}
 
 	@Override
 	public void onRuntimeAvailable(@Nonnull IJeiRuntime jeiRuntime) {
+
+	}
+
+	@Override
+	public void registerItemSubtypes(ISubtypeRegistry subtypeRegistry) {
+
+	}
+
+	@Override
+	public void registerIngredients(IModIngredientRegistration registry) {
 
 	}
 }

--- a/src/main/java/pl/asie/charset/audio/recipe/JEITapeCraftingRecipe.java
+++ b/src/main/java/pl/asie/charset/audio/recipe/JEITapeCraftingRecipe.java
@@ -27,6 +27,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 import javax.annotation.Nonnull;
+
+import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeWrapper;
 import mezz.jei.api.recipe.IRecipeHandler;
 import mezz.jei.api.recipe.IRecipeWrapper;
@@ -70,6 +72,7 @@ public class JEITapeCraftingRecipe extends BlankRecipeWrapper implements IShaped
 
 	@Nonnull
 	@Override
+	@Deprecated
 	public List getInputs() {
 		Object[] inputs = new Object[9];
 
@@ -92,6 +95,7 @@ public class JEITapeCraftingRecipe extends BlankRecipeWrapper implements IShaped
 
 	@Nonnull
 	@Override
+	@Deprecated
 	public List<ItemStack> getOutputs() {
 		return Collections.singletonList(new ItemStack(ModCharsetAudio.tapeItem, 1, OreDictionary.WILDCARD_VALUE));
 	}
@@ -106,4 +110,22 @@ public class JEITapeCraftingRecipe extends BlankRecipeWrapper implements IShaped
 		return 3;
 	}
 
+	@Override
+	public void getIngredients(IIngredients ingredients) {
+		Object[] inputs = new Object[9];
+
+		List<String> mats = new ArrayList<String>();
+		for (ItemTape.Material m : ItemTape.Material.values()) {
+			if (OreDictionary.doesOreNameExist(m.oreDict)) {
+				mats.add(m.oreDict);
+			}
+		}
+
+		inputs[0] = inputs[1] = inputs[2] = mats;
+		inputs[3] = inputs[5] = new ItemStack(ModCharsetAudio.tapeReelItem, 1, OreDictionary.WILDCARD_VALUE);
+		inputs[6] = inputs[7] = inputs[8] = new ItemStack(Blocks.STONE_SLAB);
+
+		ingredients.setInputLists(ItemStack.class, JEIPluginCharsetAudio.jeiHelpers.getStackHelper().expandRecipeItemStackInputs(Arrays.asList(inputs)));
+		ingredients.setOutputs(ItemStack.class, JEIPluginCharsetAudio.jeiHelpers.getStackHelper().getSubtypes(new ItemStack(ModCharsetAudio.tapeItem, 1, OreDictionary.WILDCARD_VALUE)));
+	}
 }

--- a/src/main/java/pl/asie/charset/audio/recipe/JEITapeReelCraftingRecipe.java
+++ b/src/main/java/pl/asie/charset/audio/recipe/JEITapeReelCraftingRecipe.java
@@ -26,6 +26,8 @@ import net.minecraft.item.ItemStack;
 import net.minecraftforge.oredict.OreDictionary;
 
 import javax.annotation.Nonnull;
+
+import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeWrapper;
 import mezz.jei.api.recipe.IRecipeHandler;
 import mezz.jei.api.recipe.IRecipeWrapper;
@@ -68,6 +70,7 @@ public class JEITapeReelCraftingRecipe extends BlankRecipeWrapper implements ISh
 
 	@Nonnull
 	@Override
+	@Deprecated
 	public List getInputs() {
 		Object[] inputs = new Object[9];
 
@@ -88,6 +91,7 @@ public class JEITapeReelCraftingRecipe extends BlankRecipeWrapper implements ISh
 
 	@Nonnull
 	@Override
+	@Deprecated
 	public List<ItemStack> getOutputs() {
 		return Collections.singletonList(new ItemStack(ModCharsetAudio.tapeReelItem, 1, OreDictionary.WILDCARD_VALUE));
 	}
@@ -102,4 +106,22 @@ public class JEITapeReelCraftingRecipe extends BlankRecipeWrapper implements ISh
 		return 3;
 	}
 
+	@Override
+	public void getIngredients(IIngredients ingredients) {
+		Object[] inputs = new Object[9];
+
+		List<Object> mats = new ArrayList<Object>();
+		mats.add(new ItemStack(ModCharsetAudio.magneticTapeItem));
+		mats.add(null);
+
+		for (int i = 0; i < 9; i++) {
+			if (i == 4) {
+				inputs[4] = new ItemStack(ModCharsetAudio.tapeReelItem, 1, OreDictionary.WILDCARD_VALUE);
+			} else {
+				inputs[i] = mats;
+			}
+		}
+		ingredients.setInputLists(ItemStack.class, JEIPluginCharsetAudio.jeiHelpers.getStackHelper().expandRecipeItemStackInputs(Arrays.asList(inputs)));
+		ingredients.setOutputs(ItemStack.class, JEIPluginCharsetAudio.jeiHelpers.getStackHelper().getSubtypes(new ItemStack(ModCharsetAudio.tapeReelItem, 1, OreDictionary.WILDCARD_VALUE)));
+	}
 }

--- a/src/main/java/pl/asie/charset/lib/recipe/JEIPluginCharsetLib.java
+++ b/src/main/java/pl/asie/charset/lib/recipe/JEIPluginCharsetLib.java
@@ -3,7 +3,9 @@ package pl.asie.charset.lib.recipe;
 import mezz.jei.api.IJeiRuntime;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.IModRegistry;
+import mezz.jei.api.ISubtypeRegistry;
 import mezz.jei.api.JEIPlugin;
+import mezz.jei.api.ingredients.IModIngredientRegistration;
 
 import javax.annotation.Nonnull;
 
@@ -18,4 +20,14 @@ public class JEIPluginCharsetLib implements IModPlugin {
     public void onRuntimeAvailable(@Nonnull IJeiRuntime jeiRuntime) {
 
     }
+
+	@Override
+	public void registerItemSubtypes(ISubtypeRegistry subtypeRegistry) {
+
+	}
+
+	@Override
+	public void registerIngredients(IModIngredientRegistration registry) {
+
+	}
 }

--- a/src/main/java/pl/asie/charset/lib/recipe/JEIRecipeCharset.java
+++ b/src/main/java/pl/asie/charset/lib/recipe/JEIRecipeCharset.java
@@ -1,5 +1,6 @@
 package pl.asie.charset.lib.recipe;
 
+import mezz.jei.api.ingredients.IIngredients;
 import mezz.jei.api.recipe.BlankRecipeWrapper;
 import mezz.jei.api.recipe.IRecipeHandler;
 import mezz.jei.api.recipe.IRecipeWrapper;
@@ -78,6 +79,7 @@ public class JEIRecipeCharset extends BlankRecipeWrapper implements ICraftingRec
     }
 
     @Override
+    @Deprecated
     public List getInputs() {
         List<Object> mats = new ArrayList<Object>();
         for (IRecipeObject o : recipe.input) {
@@ -88,8 +90,19 @@ public class JEIRecipeCharset extends BlankRecipeWrapper implements ICraftingRec
     }
 
     @Override
+    @Deprecated
     public List<ItemStack> getOutputs() {
         Object o = recipe.output.preview();
         return o instanceof List ? (List<ItemStack>) o : (o instanceof ItemStack ? Collections.singletonList((ItemStack) o) : null);
     }
+
+	@Override
+	public void getIngredients(IIngredients ingredients) {
+		List<ItemStack> stacks = new ArrayList<ItemStack>();
+		for (IRecipeObject o : recipe.input) {
+            stacks.add((o != null && o.preview() != null) ? o.preview() instanceof ItemStack ? (ItemStack) o.preview() : null : null);
+        }
+		ingredients.setInputs(ItemStack.class, stacks);
+		ingredients.setOutput(ItemStack.class, (ItemStack) recipe.output.preview());
+	}
 }

--- a/src/main/java/pl/asie/charset/lib/render/ModelTransformer.java
+++ b/src/main/java/pl/asie/charset/lib/render/ModelTransformer.java
@@ -19,6 +19,7 @@ package pl.asie.charset.lib.render;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.renderer.block.model.IBakedModel;
+import net.minecraft.client.renderer.texture.TextureAtlasSprite;
 import net.minecraft.client.renderer.vertex.VertexFormat;
 import net.minecraft.client.renderer.vertex.VertexFormatElement;
 import net.minecraft.util.EnumFacing;
@@ -82,6 +83,11 @@ import net.minecraftforge.client.model.pipeline.UnpackedBakedQuad;
          @Override
          public void setApplyDiffuseLighting(boolean diffuse) {
              parent.setApplyDiffuseLighting(diffuse);
+         }
+         
+         @Override
+         public void setTexture(TextureAtlasSprite texture) {
+        	 parent.setTexture(texture);
          }
 
          @Override


### PR DESCRIPTION
- Updated to recommended forge 1.10.2 build, experimental MCMultiPart, and released JEI.
- Also, should fixed issue #21 with implementing setTexture() in ModelTransformer in 1.10.2.
- Deprecated old JEI methods, implemented getIngredients in JEICraftingRecipe, and added a public static  jeiHlpers into JEIPluginCharsetAudio.
- This should be on its own branch.
