### PR TITLE
Allow Double Door tweak for Modded Doors. #32

### DIFF
--- a/src/main/java/pl/asie/charset/tweaks/TweakDoubleDoors.java
+++ b/src/main/java/pl/asie/charset/tweaks/TweakDoubleDoors.java
@@ -62,12 +62,11 @@ public class TweakDoubleDoors extends Tweak {
 
 	@Override
 	public boolean init() {
-		allowedDoors.add((BlockDoor) Blocks.ACACIA_DOOR);
-		allowedDoors.add((BlockDoor) Blocks.BIRCH_DOOR);
-		allowedDoors.add((BlockDoor) Blocks.JUNGLE_DOOR);
-		allowedDoors.add((BlockDoor) Blocks.OAK_DOOR);
-		allowedDoors.add((BlockDoor) Blocks.SPRUCE_DOOR);
-		allowedDoors.add((BlockDoor) Blocks.DARK_OAK_DOOR);
+		for (Block block : Block.REGISTRY) {
+			if (block != null && block instanceof BlockDoor) {
+				allowedDoors.add((BlockDoor) block);
+			}
+		}
 		return true;
 	}
 


### PR DESCRIPTION
- Allows the double door tweak to work on other mods doors, i.e. Forestry.
- My answer for #32.
* This needs to be tested, I did test a little with iron doors.